### PR TITLE
Make iOS SDK configurable with region

### DIFF
--- a/sdk/ios/Example/iProovFirebase/ViewController.swift
+++ b/sdk/ios/Example/iProovFirebase/ViewController.swift
@@ -24,10 +24,10 @@ class ViewController: UIViewController {
         let options = Options()
         options.title = "Firebase Auth Example"
         
-        Auth.auth().createUser(withIProovUserID: userIDTextField.text!,
-                               assuranceType: .liveness,
-                               options: options,
-                               progressCallback: { progress in
+        Auth.iProov().createUser(withUserID: userIDTextField.text!,
+                                 assuranceType: .liveness,
+                                 options: options,
+                                 progressCallback: { progress in
             print(progress)
         }) { result, error in
             
@@ -48,10 +48,10 @@ class ViewController: UIViewController {
         let options = Options()
         options.title = "Firebase Auth Example"
         
-        Auth.auth().signIn(withIProovUserID: userIDTextField.text!,
-                           assuranceType: .liveness,
-                           options: options,
-                           progressCallback: { progress in
+        Auth.iProov().signIn(withUserID: userIDTextField.text!,
+                             assuranceType: .liveness,
+                             options: options,
+                             progressCallback: { progress in
             print(progress)
         }) { result, error in
             if let error = error {

--- a/sdk/ios/README.md
+++ b/sdk/ios/README.md
@@ -46,7 +46,7 @@ To sign in an existing user, simply use `Auth.iProov().signIn(withUserID:)` and 
 
 ### Advanced example
 
-Once you've got up and running with the basic example, you can now pass additional parameters to `createUser(withUserID:)` and `signIn(withUserID:)`:
+Once you've got up and running with the basic example, you can now pass additional parameters to `createUser()` and `signIn()`:
 
 - `assuranceType` - specify the assurance type (Genuine Presence Assurance or Liveness Assurance)
 - `options` - customize any [iProov SDK options](https://github.com/iproov/ios?tab=readme-ov-file#options)

--- a/sdk/ios/README.md
+++ b/sdk/ios/README.md
@@ -46,7 +46,7 @@ To sign in an existing user, simply use `Auth.iProov().signIn(withUserID:)` and 
 
 ### Advanced example
 
-Once you've got up and running with the basic example, you can now pass additional parameters to `createIProovUser()` and `signInIProovUser()`:
+Once you've got up and running with the basic example, you can now pass additional parameters to `createUser(withUserID:)` and `signIn(withUserID:)`:
 
 - `assuranceType` - specify the assurance type (Genuine Presence Assurance or Liveness Assurance)
 - `options` - customize any [iProov SDK options](https://github.com/iproov/ios?tab=readme-ov-file#options)

--- a/sdk/ios/README.md
+++ b/sdk/ios/README.md
@@ -30,7 +30,7 @@ The iProov Firebase SDK extends Firebase Auth with support for creating and sign
 To register an iProov user using Genuine Presence Assurance with the default settings:
 
 ```swift
-Auth.auth().createUser(withIProovUserID: "hello@world.com") { result, error in
+Auth.iProov().createUser(withUserID: "hello@world.com") { result, error in
     if let error = error {
         print("Error: \(error)")
         return
@@ -42,7 +42,7 @@ Auth.auth().createUser(withIProovUserID: "hello@world.com") { result, error in
 }
 ```
 
-To sign in an existing user, simply use `Auth.auth().signIn(withIProovUserID:)` and pass their `userID`.
+To sign in an existing user, simply use `Auth.iProov().signIn(withUserID:)` and pass their `userID`.
 
 ### Advanced example
 
@@ -50,7 +50,6 @@ Once you've got up and running with the basic example, you can now pass addition
 
 - `assuranceType` - specify the assurance type (Genuine Presence Assurance or Liveness Assurance)
 - `options` - customize any [iProov SDK options](https://github.com/iproov/ios?tab=readme-ov-file#options)
-- `extensionID` - if you have more than one instance of the iProov Extension installed or the extension ID is anything other than `auth-iproov`, you can override it here
 - `progressCallback` - progress callbacks from iProov indicating face scan progress
 
 Here's an example, creating an iProov user with Liveness Assurance, specifying a custom title for the face scan and listening to the iProov SDK callback events:
@@ -59,10 +58,10 @@ Here's an example, creating an iProov user with Liveness Assurance, specifying a
 let options = Options()
 options.title = "Firebase Auth Example"
 
-Auth.auth().createUser(withIProovUserID: "hello@world.com",
-                       assuranceType: .liveness,
-                       options: options,
-                       progressCallback: { progress in
+Auth.iProov().createUser(withUserID: "hello@world.com",
+                         assuranceType: .liveness,
+                         options: options,
+                         progressCallback: { progress in
     print(progress)
 }) { result, error in
     if let error = error {
@@ -74,6 +73,13 @@ Auth.auth().createUser(withIProovUserID: "hello@world.com",
         print("User ID: \(user.uid))
     }
 }
+```
+
+You can also pass additional parameters to `Auth.iProov()` if your extension ID is anything other than `iproov-auth` and/or your extension is installed in a region other than `us-central1`, e.g.:
+
+```swift
+Auth.iProov(region: "europe-west2",
+            extensionID: "auth-iproov-3bau")
 ```
 
 ## Example app

--- a/sdk/ios/iProovFirebase/Classes/IProovFirebase.swift
+++ b/sdk/ios/iProovFirebase/Classes/IProovFirebase.swift
@@ -42,7 +42,9 @@ public final class IProovAuth {
          region: String = "us-central1",
          extensionID: String = "auth-iproov") {
         
-        let app = (app ?? FirebaseApp.app())!
+        guard let app = app else {
+            fatalError("No Firebase app configured")
+        }
         
         self.auth = Auth.auth(app: app)
         self.functions = Functions.functions(app: app, region: region)


### PR DESCRIPTION
The Firebase Functions SDK uses `us-central1` by default. However, if a developer installs the extension to a different region, they need a way to change this setting.

We need a way to expose this, similar to `extensionID`. However, to avoid a proliferation of such configuration settings which will need to be configured in multiple places, I have refactored this code which requires a small breaking change to the SDK.

We will also need to make this change to the Android & Flutter SDKs
