### PR TITLE
Added Terms of Use, Acceptable Use Policy & Data Processing Addendum

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Version 0.3.0
 
-- Added Terms of Service
+- Added iProov Firebase Extension Terms of Use, Acceptable Use & Data Processing Addendum
 
 ## Version 0.2.0
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.3.0
+
+- Added Terms of Service
+
 ## Version 0.2.0
 
 - Support for defined assurance types

--- a/extension/POSTINSTALL.md
+++ b/extension/POSTINSTALL.md
@@ -2,7 +2,26 @@
 
 [Supported roles for Firebase Extensions](https://firebase.google.com/docs/extensions/publishers/access#supported-roles) does not currently include `projects.serviceAccounts.signJwt` which is required for this Extension to work.
 
-Therefore, you must complete the following manual steps to finalize the Extension setup process:
+Therefore, you must complete the following manual steps to finalize the Extension setup process, using either the `gcloud` CLI tool (recommended), or manually with the Google Cloud Console web interface.
+
+## Using `gcloud` CLI (recommended)
+
+1. If you haven't already, install the Google Cloud SDK and login to your Google account (you can skip this step if `gcloud` is already setup on your machine):
+
+    ```sh
+    brew install gcloud
+    gcloud login
+    ```
+
+2. Execute the following:
+
+    ```sh
+    gcloud projects add-iam-policy-binding ${param:PROJECT_ID} --member=serviceAccount:ext-${param:EXT_INSTANCE_ID}@${param:PROJECT_ID}.iam.gserviceaccount.com --role=roles/iam.serviceAccountTokenCreator
+    ```
+
+3. Wait a few minutes for the changes to fully propagate.
+
+## Using the Google Cloud Console
 
 1. [Open the Google Cloud Console IAM Admin page](https://console.cloud.google.com/iam-admin/iam).
 

--- a/extension/extension.yaml
+++ b/extension/extension.yaml
@@ -1,5 +1,5 @@
 name: auth-iproov
-version: 0.2.0
+version: 0.3.0
 specVersion: v1beta
 displayName: Authenticate with iProov
 description: >-
@@ -87,3 +87,14 @@ params:
     description: >-
       Your iProov API secret. Leave blank to use the sandbox environment.
     type: secret
+  - param: ACCEPTED_TOS
+    label: Accepted Terms of Service
+    required: true
+    description: >-
+      I have read and accept the iProov Firebase Extension Terms of Service at https://iproov.com/firebase/terms.
+    type: select
+    options:
+      - label: Agree
+        value: true
+      - label: Disagree
+        value: false

--- a/extension/extension.yaml
+++ b/extension/extension.yaml
@@ -88,13 +88,15 @@ params:
       Your iProov API secret. Leave blank to use the sandbox environment.
     type: secret
   - param: ACCEPTED_TOS
-    label: Accepted Terms of Service
+    label: I have read and I acknowledge and accept the iProov Firebase Extension Terms of Use, Data Processing Addendum and Acceptable Use Policy
     required: true
     description: >-
-      I have read and accept the iProov Firebase Extension Terms of Service at https://iproov.com/firebase/terms.
+      Terms of Use: https://www.iproov.com/app-policies/firebase/terms-of-use<br><br>
+      Acceptable Use Policy: https://www.iproov.com/app-policies/firebase/acceptable-use-policy<br><br>
+      Data Processing Addendum: https://www.iproov.com/app-policies/firebase/data-processing-addendum 
     type: select
     options:
-      - label: Agree
+      - label: I agree
         value: true
-      - label: Disagree
+      - label: I disagree
         value: false

--- a/extension/functions/index.js
+++ b/extension/functions/index.js
@@ -14,6 +14,7 @@ const ASSURANCE_TYPES = process.env.ASSURANCE_TYPES.split(',');
 admin.initializeApp();
 
 export const getToken = functions.https.onCall(async (data, context) => {
+  checkTosAccepted();
 
   const schema = Joi.object({
     userId: Joi.string().required(),
@@ -41,6 +42,7 @@ export const getToken = functions.https.onCall(async (data, context) => {
 });
 
 export const validate = functions.https.onCall(async (data, context) => {
+  checkTosAccepted();
 
   const schema = Joi.object({
     userId: Joi.string().required(),
@@ -126,4 +128,10 @@ async function signJwt(payload) {
 
   const response = await iamcredentials.projects.serviceAccounts.signJwt(request);
   return response.data.signedJwt;
+}
+
+function checkTosAccepted() {
+  if (process.env.ACCEPTED_TOS !== 'true') {
+    throw new functions.https.HttpsError('failed-precondition', 'Terms of Service not accepted');
+  }
 }

--- a/extension/local/extensions/auth-iproov.env
+++ b/extension/local/extensions/auth-iproov.env
@@ -1,2 +1,3 @@
 REGION=eu
 ASSURANCE_TYPES=genuine_presence,liveness
+ACCEPTED_TOS=true


### PR DESCRIPTION
The developer is now required to agree to iProov's Terms of Use, Acceptable Use Policy & Data Processing Addendum when installing the Firebase Extension.

Also added instructions to POSTINSTALL on how to add the "Service Account Token Creator" role via the `gcloud` CLI rather than the GCP console.